### PR TITLE
[RTM] Add css classes to the widget with wizard

### DIFF
--- a/src/View/DefaultWidgetBuilder.php
+++ b/src/View/DefaultWidgetBuilder.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general-contao-frontend.
  *
- * (c) 2015 Contao Community Alliance.
+ * (c) 2015-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,7 +12,8 @@
  *
  * @package    contao-community-alliance/dc-general-contao-frontend
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2015 Contao Community Alliance.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2015-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general-contao-frontend/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -85,6 +86,20 @@ class DefaultWidgetBuilder
 
         $propExtra['required']  = ($varValue == '') && !empty($propExtra['mandatory']);
         $propExtra['tableless'] = true;
+        if (isset($propExtra['datepicker'])) {
+            $propExtra['class'] = $this->addCssClass($propExtra['class'], 'datepicker');
+            $propExtra['class'] = $this->addCssClass($propExtra['class'], '-' . $propExtra['rgxp']);
+        }
+        if (isset($propExtra['colorpicker'])) {
+            $propExtra['class'] = $this->addCssClass($propExtra['class'], 'colorpicker');
+            if (isset($propExtra['isHexColor'])) {
+                $propExtra['class'] = $this->addCssClass($propExtra['class'], '-hex-color');
+            }
+        }
+        if (isset($propExtra['rte'])) {
+            $propExtra['class'] = $this->addCssClass($propExtra['class'], 'rte');
+            $propExtra['class'] = $this->addCssClass($propExtra['class'], '-' . $propExtra['rte']);
+        }
 
         $arrConfig = array(
             'inputType' => $property->getWidgetType(),
@@ -174,5 +189,25 @@ class DefaultWidgetBuilder
         }
 
         return $options;
+    }
+
+
+    /**
+     * Add a css class to a string of existing css classes.
+     *
+     * @param string $classString The string to append the css class to
+     * @param string $class       The css class to add
+     *
+     * @return string
+     */
+    private function addCssClass($classString, $class)
+    {
+        if (null !== $classString) {
+            $classString .= ' ' . $class;
+        } else {
+            $classString = $class;
+        }
+
+        return $classString;
     }
 }


### PR DESCRIPTION
See #2. Add css classes to widgets with wizard and let the frontend developer implement the widgets on himself/hisself.

Results in
```html
<div class="widget widget-text datepicker -time">
    <label class="datepicker -time" for="ctrl_start_of_work">Start of work</label> <input class="text datepicker -time" id="ctrl_start_of_work" name="start_of_work" type="text" value="07:00">
</div>
<div class="widget widget-text datepicker -date">
    <label class="datepicker -date" for="ctrl_start_of_employment">Start of employment</label> <input class="text datepicker -date" id="ctrl_start_of_employment" name="start_of_employment" type="text" value="2017-04-01">
</div>
<div class="widget widget-text colorpicker -hex-color">
    <label class="colorpicker -hex-color" for="ctrl_wristband_color">Wristband color</label> <input class="text colorpicker -hex-color" id="ctrl_wristband_color" maxlength="6" name="wristband_color" type="text" value="">
</div>
<div class="widget widget-textarea rte -tinyMCE">
    <label class="rte -tinyMCE" for="ctrl_biography">Biography</label> 
    <textarea class="textarea rte -tinyMCE" cols="80" id="ctrl_biography" name="biography" rows="12"></textarea>
</div>
```

cc @stefanheimes 