### PR TITLE
[RFC] Ensure Model is not null in the EditMask

### DIFF
--- a/src/View/ActionHandler/EditHandler.php
+++ b/src/View/ActionHandler/EditHandler.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general-contao-frontend.
  *
- * (c) 2015 Contao Community Alliance.
+ * (c) 2015-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,13 +12,15 @@
  *
  * @package    contao-community-alliance/dc-general-contao-frontend
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2015 Contao Community Alliance.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2015-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general-contao-frontend/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 
 namespace ContaoCommunityAlliance\DcGeneral\ContaoFrontend\View\ActionHandler;
 
+use Contao\CoreBundle\Exception\PageNotFoundException;
 use ContaoCommunityAlliance\DcGeneral\ContaoFrontend\View\EditMask;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\BasicDefinitionInterface;
@@ -56,7 +58,11 @@ class EditHandler extends AbstractHandler
         $dataProvider = $environment->getDataProvider();
         $model        = $dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId()));
         $clone        = $dataProvider->getEmptyModel();
-        $editMask     = new EditMask($environment, $model, $clone, null, null);
+
+        if (null === $model) {
+            throw new PageNotFoundException('MetaModel not found: ' . $modelId->getSerialized());
+        }
+        $editMask = new EditMask($environment, $model, $clone, null, null);
 
         $event->setResponse($editMask->execute());
     }


### PR DESCRIPTION
Fixes #9.

Actually, we can also set a custom response like this `$event->setResponse('Item not found');`
but I think, throwing the 404 page is more consistent.